### PR TITLE
feat: Implement comprehensive spare pieces functionality with drag-an…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -320,8 +320,8 @@
   border-radius: 15px; /* Match board-column border-radius */
   border: none; /* Remove border */
   box-shadow: 0 8px 25px var(--shadow-primary); /* Match board-column box-shadow */
-  width: 284px;
-  min-width: 284px;
+  width: 12%;
+  min-width: 12%;
   overflow-y: auto;
   padding: 1.2rem 0.8rem; /* Match main-content padding exactly */
   transition: background 0.3s ease, box-shadow 0.3s ease; /* Match board-column transition */
@@ -602,10 +602,10 @@
 
 /* Boards Manager Styles */
 .boards-manager {
-  border: none;
+  border: 1px solid rgba(56, 55, 55, 0.1);
   border-radius: 0;
   overflow: hidden;
-  background: transparent;
+  background: 1px solid rgba(56, 55, 55, 0.1);
   box-shadow: none;
   backdrop-filter: none;
 }
@@ -918,14 +918,230 @@
 }
 
 .current-board-name {
-  /* margin: 10px; */
-  margin-left: 5px;
-  font-size: .9rem;
-  font-weight: 500;
-  /* color: var(--text-primary); */
+  display: none; /* Hidden by default for desktop */
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
   text-align: center;
   text-shadow: 0 1px 2px var(--text-shadow);
   transition: all 0.3s ease;
+}
+
+/* Board with spare pieces container */
+.board-with-pieces {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin: 8px 0;
+  width: 98%;
+}
+
+.spare-pieces-top,
+.spare-pieces-bottom {
+  width: 80%;
+  display: flex;
+  justify-content: center;
+  height: auto;
+}
+
+/* Spare Pieces Styling */
+.spare-pieces-container {
+  background: var(--bg-secondary);
+  /* background-color: #aaa69a; */
+  opacity: 50%;
+  border-radius: 6px;
+  /* box-shadow: 0 1px 4px var(--shadow-primary); */
+  /* border: 1px solid var(--border-secondary); */
+  padding: 6px;
+  margin: 0;
+  transition: all 0.3s ease;
+  display: inline-block;
+}
+
+.spare-pieces-top {
+  order: -1; /* Ensure it appears before the board */
+}
+
+.spare-pieces-bottom {
+  order: 1; /* Ensure it appears after the board */
+}
+
+.spare-pieces-grid {
+  display: flex;
+  gap: 1%;
+  justify-content: center;
+  flex-wrap: nowrap;
+  align-items: center;
+  height: auto;
+}
+
+.spare-piece {
+  width: 25%;
+  height: 4rem;
+  background-color: var(--bg-tertiary);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 1px;
+  cursor: grab;
+  transition: all 0.2s ease;
+  border: 1px solid var(--border-secondary);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.spare-piece:hover {
+  transform: scale(1.1);
+  background-color: var(--bg-secondary);
+  border-color: var(--border-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.spare-piece:active {
+  cursor: grabbing;
+  transform: scale(0.95);
+  background-color: var(--bg-primary);
+}
+
+/* White pieces - using exact chessground cburnett SVGs */
+.spare-piece.pawn.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PHBhdGggZD0iTTIyLjUgOWMtMi4yMSAwLTQgMS43OS00IDQgMCAuODkuMjkgMS43MS43OCAyLjM4QzE3LjMzIDE2LjUgMTYgMTguNTkgMTYgMjFjMCAyLjAzLjk0IDMuODQgMi40MSA1LjAzLTMgMS4wNi03LjQxIDUuNTUtNy40MSAxMy40N2gyM2MwLTcuOTItNC40MS0xMi40MS03LjQxLTEzLjQ3IDEuNDctMS4xOSAyLjQxLTMgMi40MS01LjAzIDAtMi40MS0xLjMzLTQuNS0zLjI4LTUuNjIuNDktLjY3Ljc4LTEuNDkuNzgtMi4zOCAwLTIuMjEtMS43OS00LTQtNHoiIGZpbGw9IiNmZmYiIHN0cm9rZT0iIzAwMCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjwvc3ZnPg==');
+}
+
+.spare-piece.rook.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0iI2ZmZiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik05IDM5aDI3di0zSDl2M3ptMy0zdi00aDIxdjRIMTJ6bS0xLTIyVjloNHYyaDVWOWg1djJoNVY5aDR2NSIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48cGF0aCBkPSJNMzQgMTRsLTMgM0gxNGwtMy0zIi8+PHBhdGggZD0iTTMxIDE3djEyLjVIMTRWMTciIHN0cm9rZS1saW5lY2FwPSJidXR0IiBzdHJva2UtbGluZWpvaW49Im1pdGVyIi8+PHBhdGggZD0iTTMxIDI5LjVsMS41IDIuNWgtMjBsMS41LTIuNSIvPjxwYXRoIGQ9Ik0xMSAxNGgyMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVqb2luPSJtaXRlciIvPjwvZz48L3N2Zz4=');
+}
+
+.spare-piece.knight.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0yMiAxMGMxMC41IDEgMTYuNSA4IDE2IDI5SDE1YzAtOSAxMC02LjUgOC0yMSIgZmlsbD0iI2ZmZiIvPjxwYXRoIGQ9Ik0yNCAxOGMuMzggMi45MS01LjU1IDcuMzctOCA5LTMgMi0yLjgyIDQuMzQtNSA0LTEuMDQyLS45NCAxLjQxLTMuMDQgMC0zLTEgMCAuMTkgMS4yMy0xIDItMSAwLTQuMDAzIDEtNC00IDAtMiA2LTEyIDYtMTJzMS44OS0xLjkgMi0zLjVjLS43My0uOTk0LS41LTItLjUtMyAxLTEgMyAyLjUgMyAyLjVoMnMuNzgtMS45OTIgMi41LTNjMSAwIDEgMyAxIDMiIGZpbGw9IiNmZmYiLz48cGF0aCBkPSJNOS41IDI1LjVhLjUuNSAwIDEgMS0xIDAgLjUuNSAwIDEgMSAxIDB6bTUuNDMzLTkuNzVhLjUgMS41IDMwIDEgMS0uODY2LS41LjUgMS41IDMwIDEgMSAuODY2LjV6IiBmaWxsPSIjMDAwIi8+PC9nPjwvc3ZnPg==');
+}
+
+.spare-piece.bishop.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxnIGZpbGw9IiNmZmYiIHN0cm9rZS1saW5lY2FwPSJidXR0Ij48cGF0aCBkPSJNOSAzNmMzLjM5LS45NyAxMC4xMS40MyAxMy41LTIgMy4zOSAyLjQzIDEwLjExIDEuMDMgMTMuNSAyIDAgMCAxLjY1LjU0IDMgMi0uNjguOTctMS42NS45OS0zIC41LTMuMzktLjk3LTEwLjExLjQ2LTEzLjUtMS0zLjM5IDEuNDYtMTAuMTEuMDMtMTMuNSAxLTEuMzU0LjQ5LTIuMzIzLjQ3LTMtLjUgMS4zNTQtMS45NCAzLTIgMy0yeiIvPjxwYXRoIGQ9Ik0xNSAzMmMyLjUgMi41IDEyLjUgMi41IDE1IDAgLjUtMS41IDAtMiAwLTIgMC0yLjUtMi41LTQtMi41LTQgNS41LTEuNSA2LTExLjUtNS0xNS41LTExIDQtMTAuNSAxNC01IDE1LjUgMCAwLTIuNSAxLjUtMi41IDQgMCAwLS41LjUgMCAyeiIvPjxwYXRoIGQ9Ik0yNSA4YTIuNSAyLjUgMCAxIDEtNSAwIDIuNSAyLjUgMCAxIDEgNSAweiIvPjwvZz48cGF0aCBkPSJNMTcuNSAyNmgxME0xNSAzMGgxNW0tNy41LTE0LjV2NU0yMCAxOGg1IiBzdHJva2UtbGluZWpvaW49Im1pdGVyIi8+PC9nPjwvc3ZnPg==');
+}
+
+.spare-piece.queen.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0iI2ZmZiIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik04IDEyYTIgMiAwIDEgMS00IDAgMiAyIDAgMSAxIDQgMHptMTYuNS00LjVhMiAyIDAgMSAxLTQgMCAyIDIgMCAxIDEgNCAwek00MSAxMmEyIDIgMCAxIDEtNCAwIDIgMiAwIDEgMSA0IDB6TTE2IDguNWEyIDIgMCAxIDEtNCAwIDIgMiAwIDEgMSA0IDB6TTMzIDlhMiAyIDAgMSAxLTQgMCAyIDIgMCAxIDEgNCAweiIvPjxwYXRoIGQ9Ik05IDI2YzguNS0xLjUgMjEtMS41IDI3IDBsMi0xMi03IDExVjExbC01LjUgMTMuNS0zLTE1LTMgMTUtNS41LTE0VjI1TDcgMTRsMiAxMnoiIHN0cm9rZS1saW5lY2FwPSJidXR0Ii8+PHBhdGggZD0iTTkgMjZjMCAyIDEuNSAyIDIuNSA0IDEgMS41IDEgMSAuNSAzLjUtMS41IDEtMS41IDIuNS0xLjUgMi41LTEuNSAxLjUuNSAyLjUuNSAyLjUgNi41IDEgMTYuNSAxIDIzIDAgMCAwIDEuNS0xIDAtMi41IDAgMCAuNS0xLjUtMS0yLjUtLjUtMi41LS41LTIgLjUtMy41IDEtMiAyLjUtMiAyLjUtNC04LjUtMS5zLTE4LjUtMS41LTI3IDB6IiBzdHJva2UtbGluZWNhcD0iYnV0dCIvPjxwYXRoIGQ9Ik0xMS41IDMwYzMuNS0xIDE4LjUtMSAyMiAwTTEyIDMzLjVjNi0xIDE1LTEgMjEgMCIgZmlsbD0ibm9uZSIvPjwvZz48L3N2Zz4=');
+}
+
+.spare-piece.king.white {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0yMi41IDExLjYzVjZNMjAgOGg1IiBzdHJva2UtbGluZWpvaW49Im1pdGVyIi8+PHBhdGggZD0iTTIyLjUgMjVzNC41LTcuNSAzLTEwLjVjMCAwLTEtMi41LTMtMi41cy0zIDIuNS0zIDIuNWMtMS41IDMgMyAxMC41IDMgMTAuNSIgZmlsbD0iI2ZmZiIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiLz48cGF0aCBkPSJNMTEuNSAzN2M1LjUgMy41IDE1LjUgMy41IDIxIDB2LTdzOS00LjUgNi0xMC41Yy00LTYuNS0xMy41LTMuNS0xNiA0VjI3di0zLjVjLTMuNS03LjUtMTMtMTAuNS0xNi00LTMgNiA1IDEwIDUgMTBWMzd6IiBmaWxsPSIjZmZmIi8+PHBhdGggZD0iTTExLjUgMzBjNS41LTMgMTUuNS0zIDIxIDBtLTIxIDMuNWM1LjUtMyAxNS41LTMgMjEgMG0tMjEgMy41YzUuNS0zIDE1LjUtMyAyMSAwIi8+PC9nPjwvc3ZnPg==');
+}
+
+/* Black pieces - using exact chessground cburnett SVGs */
+.spare-piece.pawn.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PHBhdGggZD0iTTIyLjUgOWMtMi4yMSAwLTQgMS43OS00IDQgMCAuODkuMjkgMS43MS43OCAyLjM4QzE3LjMzIDE2LjUgMTYgMTguNTkgMTYgMjFjMCAyLjAzLjk0IDMuODQgMi40MSA1LjAzLTMgMS4wNi03LjQxIDUuNTUtNy40MSAxMy40N2gyM2MwLTcuOTItNC40MS0xMi40MS03LjQxLTEzLjQ3IDEuNDctMS4xOSAyLjQxLTMgMi40MS01LjAzIDAtMi40MS0xLjMzLTQuNS0zLjI4LTUuNjIuNDktLjY3Ljc4LTEuNDkuNzgtMi4zOCAwLTIuMjEtMS43OS00LTQtNHoiIHN0cm9rZT0iIzAwMCIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjwvc3ZnPg==');
+}
+
+.spare-piece.rook.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik05IDM5aDI3di0zSDl2M3ptMy41LTdsMS41LTIuNWgxN2wxLjUgMi41aC0yMHptLS41IDR2LTRoMjF2NEgxMnoiIHN0cm9rZS1saW5lY2FwPSJidXR0Ii8+PHBhdGggZD0iTTE0IDI5LjV2LTEzaDE3djEzSDE0eiIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiLz48cGF0aCBkPSJNMTQgMTYuNUwxMSAxNGgyM2wtMyAyLjVIMTR6TTExIDE0VjloNHYyaDVWOWg1djJoNVY5aDR2NUgxMXoiIHN0cm9rZS1saW5lY2FwPSJidXR0Ii8+PHBhdGggZD0iTTEyIDM1LjVoMjFtLTIwLTRoMTltLTE4LTJoMTdtLTE3LTEzaDE3TTExIDE0aDIzIiBmaWxsPSJub25lIiBzdHJva2U9IiNlY2VjZWMiIHN0cm9rZS13aWR0aD0iMSIgc3Ryb2tlLWxpbmVqb2luPSJtaXRlciIvPjwvZz48L3N2Zz4=');
+}
+
+.spare-piece.knight.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0yMiAxMGMxMC41IDEgMTYuNSA4IDE2IDI5SDE1YzAtOSAxMC02LjUgOC0yMSIgZmlsbD0iIzAwMCIvPjxwYXRoIGQ9Ik0yNCAxOGMuMzggMi45MS01LjU1IDcuMzctOCA5LTMgMi0yLjgyIDQuMzQtNSA0LTEuMDQyLS45NCAxLjQxLTMuMDQgMC0zLTEgMCAuMTkgMS4yMy0xIDItMSAwLTQuMDAzIDEtNC00IDAtMiA2LTEyIDYtMTJzMS44OS0xLjkgMi0zLjVjLS43My0uOTk0LS41LTItLjUtMyAxLTEgMyAyLjUgMyAyLjVoMnMuNzgtMS45OTIgMi41LTNjMSAwIDEgMyAxIDMiIGZpbGw9IiMwMDAiLz48cGF0aCBkPSJNOS41IDI1LjVhLjUuNSAwIDEgMS0xIDAgLjUuNSAwIDEgMSAxIDB6bTUuNDMzLTkuNzVhLjUgMS41IDMwIDEgMS0uODY2LS41LjUgMS41IDMwIDEgMSAuODY2LjV6IiBmaWxsPSIjZWNlY2VjIiBzdHJva2U9IiNlY2VjZWMiLz48cGF0aCBkPSJNMjQuNTUgMTAuNGwtLjQ1IDEuNDUuNS4xNWMzLjE1IDEgNS42NSAyLjQ5IDcuOSA2Ljc1UzM1Ljc1IDI5LjA2IDM1LjI1IDM5bC0uMDUuNWgyLjI1bC4wNS0uNWMuNS0xMC4wNi0uODgtMTYuODUtMy4yNS0yMS4zNC0yLjM3LTQuNDktNS43OS02LjY0LTkuMTktNy4xNmwtLjUxLS4xeiIgZmlsbD0iI2VjZWNlYyIgc3Ryb2tlPSJub25lIi8+PC9nPjwvc3ZnPg==');
+}
+
+.spare-piece.bishop.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxnIGZpbGw9IiMwMDAiIHN0cm9rZS1saW5lY2FwPSJidXR0Ij48cGF0aCBkPSJNOSAzNmMzLjM5LS45NyAxMC4xMS40MyAxMy41LTIgMy4zOSAyLjQzIDEwLjExIDEuMDMgMTMuNSAyIDAgMCAxLjY1LjU0IDMgMi0uNjguOTctMS42NS45OS0zIC41LTMuMzktLjk3LTEwLjExLjQ2LTEzLjUtMS0zLjM5IDEuNDYtMTAuMTEuMDMtMTMuNSAxLTEuMzU0LjQ5LTIuMzIzLjQ3LTMtLjUgMS4zNTQtMS45NCAzLTIgMy0yeiIvPjxwYXRoIGQ9Ik0xNSAzMmMyLjUgMi41IDEyLjUgMi41IDE1IDAgLjUtMS41IDAtMiAwLTIgMC0yLjUtMi41LTQtMi41LTQgNS41LTEuNSA2LTExLjUtNS0xNS41LTExIDQtMTAuNSAxNC01IDE1LjUgMCAwLTIuNSAxLjUtMi41IDQgMCAwLS41LjUgMCAyeiIvPjxwYXRoIGQ9Ik0yNSA4YTIuNSAyLjUgMCAxIDEtNSAwIDIuNSAyLjUgMCAxIDEgNSAweiIvPjwvZz48cGF0aCBkPSJNMTcuNSAyNmgxME0xNSAzMGgxNW0tNy41LTE0LjV2NU0yMCAxOGg1IiBzdHJva2U9IiNlY2VjZWMiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiLz48L2c+PC9zdmc+');
+}
+
+.spare-piece.queen.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxnIHN0cm9rZT0ibm9uZSI+PGNpcmNsZSBjeD0iNiIgY3k9IjEyIiByPSIyLjc1Ii8+PGNpcmNsZSBjeD0iMTQiIGN5PSI5IiByPSIyLjc1Ii8+PGNpcmNsZSBjeD0iMjIuNSIgY3k9IjgiIHI9IjIuNzUiLz48Y2lyY2xlIGN4PSIzMSIgY3k9IjkiIHI9IjIuNzUiLz48Y2lyY2xlIGN4PSIzOSIgY3k9IjEyIiByPSIyLjc1Ii8+PC9nPjxwYXRoIGQ9Ik05IDI2YzguNS0xLjUgMjEtMS41IDI3IDBsMi41LTEyLjVMMzEgMjVsLS4zLTE0LjEtNS4yIDEzLjYtMy0xNC41LTMgMTQuNS01LjItMTMuNkwxNCAyNSA2LjUgMTMuNSA5IDI2eiIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48cGF0aCBkPSJNOSAyNmMwIDIgMS41IDIgMi41IDQgMSAxLjUgMSAxIC41IDMuNS0xLjUgMS0xLjUgMi41LTEuNSAyLjUtMS41IDEuNS41IDIuNS41IDIuNSA2LjUgMSAxNi41IDEgMjMgMCAwIDAgMS41LTEgMC0yLjUgMCAwIC41LTEuNS0xLTIuNS0uNS0yLjUtLjUtMiAuNS0zLjUgMS0yIDIuNS0yIDIuNS00LTguNS0xLjUtMTguNS0xLjUtMjcgMHoiIHN0cm9rZS1saW5lY2FwPSJidXR0Ii8+PHBhdGggZD0iTTExIDM4LjVhMzUgMzUgMSAwIDAgMjMgMCIgZmlsbD0ibm9uZSIgc3Ryb2tlLWxpbmVjYXA9ImJ1dHQiLz48cGF0aCBkPSJNMTEgMjlhMzUgMzUgMSAwIDEgMjMgMG0tMjEuNSAyLjVoMjBtLTIxIDNhMzUgMzUgMSAwIDAgMjIgMG0tMjMgM2EzNSAzNSAxIDAgMCAyNCAwIiBmaWxsPSJub25lIiBzdHJva2U9IiNlY2VjZWMiLz48L2c+PC9zdmc+');
+}
+
+.spare-piece.king.black {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0NSIgaGVpZ2h0PSI0NSI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxwYXRoIGQ9Ik0yMi41IDExLjYzVjYiIHN0cm9rZS1saW5lam9pbj0ibWl0ZXIiLz48cGF0aCBkPSJNMjIuNSAyNXM0LjUtNy41IDMtMTAuNWMwIDAtMS0yLjUtMy0yLjVzLTMgMi41LTMgMi41Yy0xLjUgMyAzIDEwLjUgMyAxMC41IiBmaWxsPSIjMDAwIiBzdHJva2UtbGluZWNhcD0iYnV0dCIgc3Ryb2tlLWxpbmVqb2luPSJtaXRlciIvPjxwYXRoIGQ9Ik0xMS41IDM3YzUuNSAzLjUgMTUuNSAzLjUgMjEgMHYtN3M5LTQuNSA2LTEwLjVjLTQtNi41LTEzLjUtMy41LTE2IDRWMjd2LTMuNWMtMy41LTcuNS0xMy0xMC41LTE2LTQtMyA2IDUgMTAgNSAxMFYzN3oiIGZpbGw9IiMwMDAiLz48cGF0aCBkPSJNMjAgOGg1IiBzdHJva2UtbGluZWpvaW49Im1pdGVyIi8+PHBhdGggZD0iTTMyIDI5LjVzOC41LTQgNi4wMy05LjY1QzM0LjE1IDE0IDI1IDE4IDIyLjUgMjQuNWwuMDEgMi4xLS4wMS0yLjFDMjAgMTggOS45MDYgMTQgNi45OTcgMTkuODVjLTIuNDk3IDUuNjUgNC44NTMgOSA0Ljg1MyA5IiBzdHJva2U9IiNlY2VjZWMiLz48cGF0aCBkPSJNMTEuNSAzMGM1LjUtMyAxNS41LTMgMjEgMG0tMjEgMy41YzUuNS0zIDE1LjUtMyAyMSAwbS0yMSAzLjVjNS41LTMgMTUuNS0zIDIxIDAiIHN0cm9rZT0iI2VjZWNlYyIvPjwvZz48L3N2Zz4=');
+}
+
+.spare-pieces-info {
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
+.spare-pieces-info small {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+/* Mobile responsiveness for spare pieces */
+@media (max-width: 768px) {
+  .current-board-name {
+    display: block; /* Show board name on mobile */
+  }
+  
+  .board-with-pieces {
+    gap: 3px;
+    margin: 4px 0;
+  }
+  
+  .spare-pieces-container {
+    padding: 4px;
+  }
+  
+  .spare-piece {
+    width: 14%;
+    /* height: 42px; */
+    /* aspect-ratio: ; */
+  }
+  
+  .spare-pieces-grid {
+    gap: 4px;
+  }
+}
+
+@media (max-width: 480px) {
+  .board-with-pieces {
+    gap: 2px;
+  }
+  
+  .spare-piece {
+    width: 80%;
+    height: 58px;
+  }
+  
+  .spare-pieces-grid {
+    gap: 3px;
+  }
+
+  .spare-pieces-top,
+  .spare-pieces-bottom {
+    width: 90%;
+  }
+}
+
+/* Tablet responsiveness for spare pieces (769px to 1200px) */
+@media (min-width: 769px) and (max-width: 1200px) {
+  .current-board-name {
+    display: block; /* Show board name only on tablets */
+  }
+  
+  .board-with-pieces {
+    gap: 4px;
+    margin: 6px 0;
+  }
+  
+  .spare-pieces-container {
+    padding: 6px 8px;
+  }
+  
+  .spare-piece {
+    width: 13%;
+    /* height: 3.5rem; */
+  }
+  
+  .spare-pieces-grid {
+    gap: 5px;
+  }
+  
+  .spare-pieces-top,
+  .spare-pieces-bottom {
+    width: 95%;
+  }
 }
 
 .chess-board {
@@ -3873,6 +4089,14 @@ progress::-moz-progress-bar {
    CONSOLIDATED RESPONSIVE DESIGN MEDIA QUERIES
    =============================================== */
 
+/* Medium desktop screens (1200px to 1600px) */
+@media (min-width: 1200px) and (max-width: 1600px) {
+  .boards-sidebar {
+    width: 16%;
+    min-width: 12%;
+  }
+}
+
 /* Show mobile menu button on devices smaller than 1200px */
 @media (max-width: 1200px) {
   .mobile-menu-button {
@@ -3881,6 +4105,7 @@ progress::-moz-progress-bar {
 
   .boards-sidebar {
     display: none !important;
+    width: 12%;
   }
 
   .main-content {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import GameNavigation from './components/GameNavigation';
 import AnalysisResults from './components/AnalysisResults';
 import BoardsManager from './components/BoardsManager';
 import BoardNameDisplay from './components/BoardNameDisplay';
+import SparePieces from './components/SparePieces';
 import MobileNavigation from './components/MobileNavigation';
 import MobileCalculateButton from './components/MobileCalculateButton';
 import MobileBoardsSelector from './components/MobileBoardsSelector';
@@ -89,9 +90,22 @@ function App() {
             <div className="board-column">
             <MobileBoardsSelector />
             <BoardNameDisplay />
-            {/* <div className="board-section"> */}
+            
+            <div className="board-with-pieces">
+              {/* Spare pieces - component will decide which color to show based on board orientation */}
+              <div className="spare-pieces-top">
+                <SparePieces color="black" position="top" />
+                <SparePieces color="white" position="top" />
+              </div>
+              
               <ChessBoard />
-            {/* </div> */}
+              
+              <div className="spare-pieces-bottom">
+                <SparePieces color="black" position="bottom" />
+                <SparePieces color="white" position="bottom" />
+              </div>
+            </div>
+            
             <MobileCalculateButton />
             <GameNavigation />
           </div>

--- a/src/components/ChessBoard.tsx
+++ b/src/components/ChessBoard.tsx
@@ -89,7 +89,6 @@ export const ChessBoard: React.FC<ChessBoardProps> = ({ width }) => {
     clearAnalysisResults,
     setChessgroundInstance,
     placePiece,
-    removePiece,
     updateGameStateOnly,
   } = useChessStore();
 

--- a/src/components/SparePieces.tsx
+++ b/src/components/SparePieces.tsx
@@ -1,0 +1,95 @@
+import React, { useRef } from 'react';
+import { useChessStore } from '../store/chessStore';
+
+type PieceRole = 'pawn' | 'rook' | 'knight' | 'bishop' | 'queen' | 'king';
+type PieceColor = 'white' | 'black';
+
+interface Piece {
+  role: PieceRole;
+  color: PieceColor;
+}
+
+interface SparePiecesProps {
+  color: PieceColor;
+  position: 'top' | 'bottom';
+}
+
+export const SparePieces: React.FC<SparePiecesProps> = ({ color, position }) => {
+  const sparePiecesRef = useRef<HTMLDivElement>(null);
+  const { chessgroundInstance, getCurrentBoard } = useChessStore();
+  
+  // Get current board orientation
+  const currentBoard = getCurrentBoard();
+  const boardOrientation = currentBoard?.boardOrientation || 'white';
+  
+  // Determine which color should be shown based on position and orientation
+  const shouldShow = (boardOrientation === 'white' && ((position === 'top' && color === 'black') || (position === 'bottom' && color === 'white'))) ||
+                     (boardOrientation === 'black' && ((position === 'top' && color === 'white') || (position === 'bottom' && color === 'black')));
+
+  // Don't render if this position shouldn't show this color
+  if (!shouldShow) {
+    return null;
+  }
+
+  // Define pieces for the specified color
+  const pieces: Piece[] = [
+    { role: 'king', color },
+    { role: 'queen', color },
+    { role: 'rook', color },
+    { role: 'bishop', color },
+    { role: 'knight', color },
+    { role: 'pawn', color },
+  ];
+
+  // Handle drag start for pieces
+  const handleDragStart = (piece: Piece, event: React.DragEvent<HTMLDivElement>) => {
+    // Store piece data for the drop handler
+    event.dataTransfer.setData('application/json', JSON.stringify(piece));
+    event.dataTransfer.effectAllowed = 'copy';
+    
+    // Add visual feedback
+    event.currentTarget.style.opacity = '0.5';
+  };
+
+  const handleDragEnd = (event: React.DragEvent<HTMLDivElement>) => {
+    // Reset visual feedback
+    event.currentTarget.style.opacity = '1';
+  };
+
+  // Handle mouse down for Chessground integration
+  const handleMouseDown = (piece: Piece, event: React.MouseEvent<HTMLDivElement>) => {
+    // Prevent default drag behavior to allow Chessground to handle it
+    event.preventDefault();
+    
+    // Use the chessground instance from the store
+    if (chessgroundInstance && chessgroundInstance.dragNewPiece) {
+      try {
+        chessgroundInstance.dragNewPiece(piece, event.nativeEvent);
+      } catch (error) {
+        console.warn('Failed to use Chessground dragNewPiece:', error);
+      }
+    }
+  };
+
+  return (
+    <div className={`spare-pieces-container spare-pieces-${position} spare-pieces-${color}`}>
+      <div className="spare-pieces-grid" ref={sparePiecesRef}>
+        {pieces.map((piece, index) => (
+          <div
+            key={`${piece.color}-${piece.role}-${index}`}
+            className={`spare-piece piece ${piece.role} ${piece.color}`}
+            draggable
+            onDragStart={(e) => handleDragStart(piece, e)}
+            onDragEnd={handleDragEnd}
+            onMouseDown={(e) => handleMouseDown(piece, e)}
+            title={`${piece.color} ${piece.role}`}
+          >
+            {/* The piece appearance will be handled by CSS, similar to chessground */}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SparePieces;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -74,6 +74,26 @@ class ApiService {
   ): Promise<ApiResponse<T>> {
     const url = `${API_BASE_URL}${endpoint}`;
     
+    // Log chess board related API calls with detailed information
+    if (endpoint.includes('/chess-boards')) {
+      const method = options.method || 'GET';
+      console.log(`🌐 API CALL: ${method} ${endpoint}`);
+      
+      if (options.body && (method === 'POST' || method === 'PUT')) {
+        try {
+          const bodyData = JSON.parse(options.body as string);
+          if (bodyData.fen) {
+            console.log('📝 API CALL: Sending FEN:', bodyData.fen);
+          }
+          if (bodyData.gameState) {
+            console.log('🎯 API CALL: Sending game state:', bodyData.gameState);
+          }
+        } catch (e) {
+          // Body might not be JSON, that's okay
+        }
+      }
+    }
+    
     const config: RequestInit = {
       headers: {
         'Content-Type': 'application/json',
@@ -84,8 +104,18 @@ class ApiService {
     };
 
     try {
+      const startTime = Date.now();
       const response = await fetch(url, config);
       const data = await response.json();
+      const endTime = Date.now();
+      
+      // Log response details for chess board calls
+      if (endpoint.includes('/chess-boards')) {
+        console.log(`✅ API RESPONSE: ${response.status} ${response.statusText} (${endTime - startTime}ms)`);
+        if (data.success && data.data?.chessBoard?.fen) {
+          console.log('📥 API RESPONSE: Received FEN:', data.data.chessBoard.fen);
+        }
+      }
       
       if (!response.ok) {
         throw new Error(data.message || 'API request failed');
@@ -93,7 +123,10 @@ class ApiService {
       
       return data;
     } catch (error) {
-      console.error('API request error:', error);
+      console.error('❌ API ERROR:', error);
+      if (endpoint.includes('/chess-boards')) {
+        console.error('❌ CHESS BOARD API ERROR: Failed to sync with backend');
+      }
       throw error;
     }
   }


### PR DESCRIPTION
…d-drop

- Add SparePieces component with full piece set (pawns, rooks, knights, bishops, queens, kings)
- Implement drag-and-drop from spare pieces to board with chessground integration
- Add drag-off-board piece removal functionality with FEN updating
- Enhance board positioning with spare pieces above and below chess board
- Add exact chessground cburnett SVG styling for authentic piece appearance
- Implement board orientation awareness (pieces flip with board)
- Add FEN position updating and backend API synchronization
- Include responsive design for mobile, tablet, and desktop screens
- Add board name display for mobile/tablet only (hidden on desktop)
- Implement comprehensive logging for debugging drag operations
- Add sidebar width optimization for medium desktop screens (1200-1600px)
- Update chess store with placePiece, removePiece, and updateGameStateOnly methods
- Enhance API service with detailed logging for chess board operations